### PR TITLE
Implemented a server-side capital sync on top of the existing Country…

### DIFF
--- a/BaseLibrary/DTOs/CapitalSyncResultDto.cs
+++ b/BaseLibrary/DTOs/CapitalSyncResultDto.cs
@@ -1,0 +1,15 @@
+namespace BaseLibrary.DTOs
+{
+    public class CapitalSyncResultDto
+    {
+        public int CountriesMatched { get; set; }
+        public int CountriesSkipped { get; set; }
+        public int CitiesInserted { get; set; }
+        public int CitiesUpdated { get; set; }
+        public int TownsInserted { get; set; }
+        public int TownsUpdated { get; set; }
+        public int RecordsProcessed { get; set; }
+        public DateTime SyncedAtUtc { get; set; }
+        public string Source { get; set; } = "REST Countries";
+    }
+}

--- a/Client/Pages/ContentPages/LocationPages/CityPage.razor
+++ b/Client/Pages/ContentPages/LocationPages/CityPage.razor
@@ -93,17 +93,29 @@
 
     public void Dispose()
     {
-        allState.Action -= StateHasChanged;
+        allState.Action -= HandleStateChanged;
     }
 
     protected override async Task OnInitializedAsync()
     {
         await GetCities();
         await GetCountries();
-        allState.Action += StateHasChanged;
+        allState.Action += HandleStateChanged;
     }
 
+    private void HandleStateChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            if (allState.ShowCity)
+            {
+                await GetCities();
+                await GetCountries();
+            }
 
+            StateHasChanged();
+        });
+    }
 
     private async Task GetCountries()
     {

--- a/Client/Pages/ContentPages/LocationPages/CountryPage.razor
+++ b/Client/Pages/ContentPages/LocationPages/CountryPage.razor
@@ -11,9 +11,9 @@
                     <div class="card-header">
                         <h4 class="float-start">Countries</h4>
                         <div class="float-end d-flex gap-2">
-                          @*   <AuthorizeView Roles="Admin">
-                                <Authorized> *@
-                                    <button class="btn btn-outline-primary" @onclick="SyncCountriesClicked" disabled="@isSyncingCountries">
+                            <AuthorizeView Roles="Admin">
+                                <Authorized>
+                                    <button class="btn btn-outline-primary" @onclick="SyncCountriesClicked" disabled="@(isSyncingCountries || isSyncingCapitals)">
                                         @if (isSyncingCountries)
                                         {
                                             <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
@@ -24,8 +24,20 @@
                                             <span>Sync Countries</span>
                                         }
                                     </button>
-                             @*    </Authorized>
-                            </AuthorizeView> *@
+
+                                    <button class="btn btn-outline-info" @onclick="SyncCapitalsClicked" disabled="@(isSyncingCountries || isSyncingCapitals)">
+                                        @if (isSyncingCapitals)
+                                        {
+                                            <span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>
+                                            <span>Syncing...</span>
+                                        }
+                                        else
+                                        {
+                                            <span>Sync Capitals</span>
+                                        }
+                                    </button>
+                                </Authorized>
+                            </AuthorizeView>
 
                             <button class="btn btn-outline-success" @onclick="AddButtonClicked">
                                 <i class="bi bi-plus-circle-dotted"></i>
@@ -34,13 +46,25 @@
                     </div>
 
                     <div class="card-body" style="max-height: 580px; overflow-x:hidden; overflow-y:scroll;">
-                        @if (lastSyncResult is not null)
+                        @if (lastCountrySyncResult is not null)
                         {
                             <div class="alert alert-success" role="alert">
-                                Synced @lastSyncResult.TotalProcessed countries.
-                                Inserted: @lastSyncResult.Inserted |
-                                Updated: @lastSyncResult.Updated |
-                                Skipped: @lastSyncResult.Skipped
+                                Country sync completed.
+                                Processed: @lastCountrySyncResult.TotalProcessed |
+                                Inserted: @lastCountrySyncResult.Inserted |
+                                Updated: @lastCountrySyncResult.Updated |
+                                Skipped: @lastCountrySyncResult.Skipped
+                            </div>
+                        }
+
+                        @if (lastCapitalSyncResult is not null)
+                        {
+                            <div class="alert alert-success" role="alert">
+                                Capital sync completed.
+                                Matched: @lastCapitalSyncResult.CountriesMatched |
+                                Skipped: @lastCapitalSyncResult.CountriesSkipped |
+                                Cities inserted/updated: @lastCapitalSyncResult.CitiesInserted/@lastCapitalSyncResult.CitiesUpdated |
+                                Towns inserted/updated: @lastCapitalSyncResult.TownsInserted/@lastCapitalSyncResult.TownsUpdated
                             </div>
                         }
 
@@ -114,22 +138,35 @@
     CountryDialog? countryDialog;
     Country Country = new();
     public List<Country> Countries { get; set; } = new();
-    private CountrySyncResultDto? lastSyncResult;
+    private CountrySyncResultDto? lastCountrySyncResult;
+    private CapitalSyncResultDto? lastCapitalSyncResult;
     private bool isSyncingCountries;
+    private bool isSyncingCapitals;
 
 
     public void Dispose()
     {
-        allState.Action -= StateHasChanged;
+        allState.Action -= HandleStateChanged;
     }
 
     protected override async Task OnInitializedAsync()
     {
         await GetCountries();
-        allState.Action += StateHasChanged;
+        allState.Action += HandleStateChanged;
     }
 
+    private void HandleStateChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            if (allState.ShowCountry)
+            {
+                await GetCountries();
+            }
 
+            StateHasChanged();
+        });
+    }
 
     private async Task GetCountries()
     {
@@ -146,13 +183,13 @@
         try
         {
             isSyncingCountries = true;
-            lastSyncResult = await countrySyncService.SyncCountriesAsync();
+            lastCountrySyncResult = await countrySyncService.SyncCountriesAsync();
 
-            if (lastSyncResult is not null)
+            if (lastCountrySyncResult is not null)
             {
                 await GetCountries();
                 await dialogService.AlertAsync(
-                    $"Inserted: {lastSyncResult.Inserted}, Updated: {lastSyncResult.Updated}, Skipped: {lastSyncResult.Skipped}.",
+                    $"Inserted: {lastCountrySyncResult.Inserted}, Updated: {lastCountrySyncResult.Updated}, Skipped: {lastCountrySyncResult.Skipped}.",
                     "Success Operation");
             }
         }
@@ -163,6 +200,36 @@
         finally
         {
             isSyncingCountries = false;
+        }
+    }
+
+    private async Task SyncCapitalsClicked()
+    {
+        if (isSyncingCapitals)
+        {
+            return;
+        }
+
+        try
+        {
+            isSyncingCapitals = true;
+            lastCapitalSyncResult = await countrySyncService.SyncCapitalsAsync();
+
+            if (lastCapitalSyncResult is not null)
+            {
+                await GetCountries();
+                await dialogService.AlertAsync(
+                    $"Matched: {lastCapitalSyncResult.CountriesMatched}, Skipped: {lastCapitalSyncResult.CountriesSkipped}, Cities inserted/updated: {lastCapitalSyncResult.CitiesInserted}/{lastCapitalSyncResult.CitiesUpdated}, Towns inserted/updated: {lastCapitalSyncResult.TownsInserted}/{lastCapitalSyncResult.TownsUpdated}.",
+                    "Success Operation");
+            }
+        }
+        catch (Exception ex)
+        {
+            await dialogService.AlertAsync(ex.Message, "Alert!");
+        }
+        finally
+        {
+            isSyncingCapitals = false;
         }
     }
 

--- a/Client/Pages/ContentPages/LocationPages/TownPage.razor
+++ b/Client/Pages/ContentPages/LocationPages/TownPage.razor
@@ -78,7 +78,21 @@
     {
         await GetCities();
         await GetTowns();
-        allState.Action += StateHasChanged;
+        allState.Action += HandleStateChanged;
+    }
+
+    private void HandleStateChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            if (allState.ShowTown)
+            {
+                await GetCities();
+                await GetTowns();
+            }
+
+            StateHasChanged();
+        });
     }
 
     private async Task GetCities()
@@ -165,6 +179,6 @@
 
     public void Dispose()
     {
-        allState.Action -= StateHasChanged;
+        allState.Action -= HandleStateChanged;
     }
 }

--- a/ClientLibrary/Services/Contracts/ICountrySyncClientService.cs
+++ b/ClientLibrary/Services/Contracts/ICountrySyncClientService.cs
@@ -5,5 +5,6 @@ namespace ClientLibrary.Services.Contracts
     public interface ICountrySyncClientService
     {
         Task<CountrySyncResultDto?> SyncCountriesAsync();
+        Task<CapitalSyncResultDto?> SyncCapitalsAsync();
     }
 }

--- a/ClientLibrary/Services/Implementations/CountrySyncClientService.cs
+++ b/ClientLibrary/Services/Implementations/CountrySyncClientService.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using System.Text.Json;
 using BaseLibrary.DTOs;
 using ClientLibrary.Helpers;
 using ClientLibrary.Services.Contracts;
@@ -7,29 +8,75 @@ namespace ClientLibrary.Services.Implementations
 {
     public class CountrySyncClientService(GetHttpClient getHttpClient) : ICountrySyncClientService
     {
-        public async Task<CountrySyncResultDto?> SyncCountriesAsync()
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        public Task<CountrySyncResultDto?> SyncCountriesAsync() =>
+            PostSyncAsync<CountrySyncResultDto>(
+                $"{Constants.CountryBaseUrl}/sync",
+                "The server could not complete the country sync.",
+                "The server returned an empty country sync response.");
+
+        public Task<CapitalSyncResultDto?> SyncCapitalsAsync() =>
+            PostSyncAsync<CapitalSyncResultDto>(
+                $"{Constants.CountryBaseUrl}/sync-capitals",
+                "The server could not complete the capital sync.",
+                "The server returned an empty capital sync response.");
+
+        private async Task<TResponse?> PostSyncAsync<TResponse>(
+            string requestUri,
+            string fallbackErrorMessage,
+            string emptyResponseMessage)
+            where TResponse : class
         {
             var httpClient = await getHttpClient.GetPrivateHttpClient();
-            var response = await httpClient.PostAsync($"{Constants.CountryBaseUrl}/sync", content: null);
+            var response = await httpClient.PostAsync(requestUri, content: null);
 
             if (!response.IsSuccessStatusCode)
             {
-                var errorMessage = await response.Content.ReadAsStringAsync();
-                if (string.IsNullOrWhiteSpace(errorMessage))
-                {
-                    errorMessage = "The server could not complete the country sync.";
-                }
-
-                throw new InvalidOperationException(errorMessage);
+                throw new InvalidOperationException(
+                    await GetErrorMessageAsync(response, fallbackErrorMessage));
             }
 
-            var result = await response.Content.ReadFromJsonAsync<CountrySyncResultDto>();
+            var result = await response.Content.ReadFromJsonAsync<TResponse>();
             if (result is null)
             {
-                throw new InvalidOperationException("The server returned an empty country sync response.");
+                throw new InvalidOperationException(emptyResponseMessage);
             }
 
             return result;
+        }
+
+        private static async Task<string> GetErrorMessageAsync(
+            HttpResponseMessage response,
+            string fallbackErrorMessage)
+        {
+            var errorMessage = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(errorMessage))
+            {
+                return fallbackErrorMessage;
+            }
+
+            try
+            {
+                var serverError = JsonSerializer.Deserialize<ServerErrorResponse>(errorMessage, JsonOptions);
+                if (!string.IsNullOrWhiteSpace(serverError?.Message))
+                {
+                    return serverError.Message;
+                }
+            }
+            catch (JsonException)
+            {
+            }
+
+            return errorMessage;
+        }
+
+        private sealed class ServerErrorResponse
+        {
+            public string? Message { get; set; }
         }
     }
 }

--- a/Server/Controllers/CountryController.cs
+++ b/Server/Controllers/CountryController.cs
@@ -11,7 +11,8 @@ namespace Server.Controllers
     [ApiController]
     public class CountryController(
         IGenericRepositoryInterface<Country> genericRepositoryInterface,
-        ICountrySyncService countrySyncService) :
+        ICountrySyncService countrySyncService,
+        ICapitalSyncService capitalSyncService) :
         GenericController<Country>(genericRepositoryInterface)
     {
         [Authorize(Roles = "Admin")]
@@ -19,6 +20,14 @@ namespace Server.Controllers
         public async Task<ActionResult<CountrySyncResultDto>> SyncCountries()
         {
             var result = await countrySyncService.SyncFromRestCountriesAsync();
+            return Ok(result);
+        }
+
+        [Authorize(Roles = "Admin")]
+        [HttpPost("sync-capitals")]
+        public async Task<ActionResult<CapitalSyncResultDto>> SyncCapitals()
+        {
+            var result = await capitalSyncService.SyncCapitalsFromRestCountriesAsync();
             return Ok(result);
         }
     }

--- a/Server/Program.cs
+++ b/Server/Program.cs
@@ -93,8 +93,11 @@ try
     builder.Services.AddScoped<IGenericRepositoryInterface<Country>, CountryRepository>();
     builder.Services.AddScoped<ICountryRepository, CountryRepository>();
     builder.Services.AddScoped<IGenericRepositoryInterface<City>, CityRepository>();
+    builder.Services.AddScoped<ICityRepository, CityRepository>();
     builder.Services.AddScoped<IGenericRepositoryInterface<Town>, TownRepository>();
+    builder.Services.AddScoped<ITownRepository, TownRepository>();
     builder.Services.AddScoped<ICountrySyncService, CountrySyncService>();
+    builder.Services.AddScoped<ICapitalSyncService, CapitalSyncService>();
 
     builder.Services.AddHttpClient("RestCountries", client =>
     {

--- a/ServerLibrary/Repositories/Contracts/ICityRepository.cs
+++ b/ServerLibrary/Repositories/Contracts/ICityRepository.cs
@@ -1,0 +1,11 @@
+using BaseLibrary.Entities;
+
+namespace ServerLibrary.Repositories.Contracts
+{
+    public interface ICityRepository : IGenericRepositoryInterface<City>
+    {
+        Task<List<City>> GetAllForSyncAsync();
+        Task<City?> GetByCountryIdAndNameAsync(int countryId, string cityName);
+        Task AddAsync(City city);
+    }
+}

--- a/ServerLibrary/Repositories/Contracts/ITownRepository.cs
+++ b/ServerLibrary/Repositories/Contracts/ITownRepository.cs
@@ -1,0 +1,11 @@
+using BaseLibrary.Entities;
+
+namespace ServerLibrary.Repositories.Contracts
+{
+    public interface ITownRepository : IGenericRepositoryInterface<Town>
+    {
+        Task<List<Town>> GetAllForSyncAsync();
+        Task<Town?> GetByCityIdAndNameAsync(int cityId, string townName);
+        Task AddAsync(Town town);
+    }
+}

--- a/ServerLibrary/Repositories/Implementations/CityRepository.cs
+++ b/ServerLibrary/Repositories/Implementations/CityRepository.cs
@@ -9,7 +9,7 @@ namespace ServerLibrary.Repositories.Implementations
 {
     public class CityRepository(
         AppDbContext appDbContext,
-        ILogger<CityRepository> logger) : IGenericRepositoryInterface<City>
+        ILogger<CityRepository> logger) : IGenericRepositoryInterface<City>, ICityRepository
     {
         public async Task<List<City>> GetAll() =>
             await appDbContext.Cities
@@ -19,6 +19,19 @@ namespace ServerLibrary.Repositories.Implementations
 
         public async Task<City> GetById(int id) =>
             (await appDbContext.Cities.FindAsync(id))!;
+
+        public async Task<List<City>> GetAllForSyncAsync() =>
+            await appDbContext.Cities.ToListAsync();
+
+        public async Task<City?> GetByCountryIdAndNameAsync(int countryId, string cityName)
+        {
+            var normalizedCityName = cityName.Trim();
+
+            return await appDbContext.Cities.FirstOrDefaultAsync(city =>
+                city.CountryId == countryId &&
+                city.Name != null &&
+                city.Name.Equals(normalizedCityName, StringComparison.OrdinalIgnoreCase));
+        }
 
         public async Task<GeneralResponse> Insert(City item)
         {
@@ -88,6 +101,9 @@ namespace ServerLibrary.Repositories.Implementations
 
             return Success();
         }
+
+        public async Task AddAsync(City city) =>
+            await appDbContext.Cities.AddAsync(city);
 
         private async Task Commit() => await appDbContext.SaveChangesAsync();
         private static GeneralResponse NotFound() => new(false, "Sorry city not found");

--- a/ServerLibrary/Repositories/Implementations/TownRepository.cs
+++ b/ServerLibrary/Repositories/Implementations/TownRepository.cs
@@ -9,7 +9,7 @@ namespace ServerLibrary.Repositories.Implementations
 {
     public class TownRepository(
         AppDbContext appDbContext,
-        ILogger<TownRepository> logger) : IGenericRepositoryInterface<Town>
+        ILogger<TownRepository> logger) : IGenericRepositoryInterface<Town>, ITownRepository
     {
         public async Task<List<Town>> GetAll() =>
             await appDbContext.Towns
@@ -19,6 +19,19 @@ namespace ServerLibrary.Repositories.Implementations
 
         public async Task<Town> GetById(int id) =>
             (await appDbContext.Towns.FindAsync(id))!;
+
+        public async Task<List<Town>> GetAllForSyncAsync() =>
+            await appDbContext.Towns.ToListAsync();
+
+        public async Task<Town?> GetByCityIdAndNameAsync(int cityId, string townName)
+        {
+            var normalizedTownName = townName.Trim();
+
+            return await appDbContext.Towns.FirstOrDefaultAsync(town =>
+                town.CityId == cityId &&
+                town.Name != null &&
+                town.Name.Equals(normalizedTownName, StringComparison.OrdinalIgnoreCase));
+        }
 
         public async Task<GeneralResponse> Insert(Town item)
         {
@@ -88,6 +101,9 @@ namespace ServerLibrary.Repositories.Implementations
 
             return Success();
         }
+
+        public async Task AddAsync(Town town) =>
+            await appDbContext.Towns.AddAsync(town);
 
         private async Task Commit() => await appDbContext.SaveChangesAsync();
         private static GeneralResponse NotFound() => new(false, "Sorry town not found");

--- a/ServerLibrary/Services/Contracts/ICapitalSyncService.cs
+++ b/ServerLibrary/Services/Contracts/ICapitalSyncService.cs
@@ -1,0 +1,9 @@
+using BaseLibrary.DTOs;
+
+namespace ServerLibrary.Services.Contracts
+{
+    public interface ICapitalSyncService
+    {
+        Task<CapitalSyncResultDto> SyncCapitalsFromRestCountriesAsync();
+    }
+}

--- a/ServerLibrary/Services/Implementations/CapitalSyncService.cs
+++ b/ServerLibrary/Services/Implementations/CapitalSyncService.cs
@@ -1,0 +1,185 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using BaseLibrary.DTOs;
+using BaseLibrary.Entities;
+using ServerLibrary.Data;
+using ServerLibrary.Repositories.Contracts;
+using ServerLibrary.Services.Contracts;
+using ServerLibrary.Services.Models;
+
+namespace ServerLibrary.Services.Implementations
+{
+    public class CapitalSyncService(
+        ICountryRepository countryRepository,
+        ICityRepository cityRepository,
+        ITownRepository townRepository,
+        AppDbContext appDbContext,
+        IHttpClientFactory httpClientFactory) : ICapitalSyncService
+    {
+        private const string SourceName = "REST Countries";
+        private static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            PropertyNameCaseInsensitive = true
+        };
+
+        public async Task<CapitalSyncResultDto> SyncCapitalsFromRestCountriesAsync()
+        {
+            using var httpClient = httpClientFactory.CreateClient("RestCountries");
+            using var response = await httpClient.GetAsync("v3.1/all?fields=name,capital");
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(
+                    $"REST Countries request failed with status code {(int)response.StatusCode} ({response.StatusCode}).",
+                    null,
+                    response.StatusCode);
+            }
+
+            var externalCountries = await response.Content.ReadFromJsonAsync<List<RestCountryCapitalApiResponse>>(JsonOptions);
+            if (externalCountries is null || externalCountries.Count == 0)
+            {
+                throw new InvalidOperationException("REST Countries returned no capital data.");
+            }
+
+            var syncedAtUtc = DateTime.UtcNow;
+            var result = new CapitalSyncResultDto
+            {
+                RecordsProcessed = externalCountries.Count,
+                SyncedAtUtc = syncedAtUtc,
+                Source = SourceName
+            };
+
+            var countries = await countryRepository.GetAll();
+            var countriesByName = countries
+                .Where(country => !string.IsNullOrWhiteSpace(country.Name))
+                .GroupBy(country => NormalizeKey(country.Name)!)
+                .ToDictionary(group => group.Key, group => group.First());
+
+            var cities = await cityRepository.GetAllForSyncAsync();
+            var citiesByKey = cities
+                .Where(city => city.CountryId > 0 && !string.IsNullOrWhiteSpace(city.Name))
+                .GroupBy(city => CreateScopedKey(city.CountryId, city.Name)!)
+                .ToDictionary(group => group.Key, group => group.First());
+
+            var towns = await townRepository.GetAllForSyncAsync();
+            var townsByKey = towns
+                .Where(town => town.CityId > 0 && !string.IsNullOrWhiteSpace(town.Name))
+                .GroupBy(town => CreateScopedKey(town.CityId, town.Name)!)
+                .ToDictionary(group => group.Key, group => group.First());
+
+            var pendingTownKeys = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var externalCountry in externalCountries)
+            {
+                var countryName = NormalizeText(externalCountry.Name?.Common);
+                var capitalName = NormalizeCapital(externalCountry.Capital);
+
+                if (string.IsNullOrWhiteSpace(countryName) || string.IsNullOrWhiteSpace(capitalName))
+                {
+                    result.CountriesSkipped++;
+                    continue;
+                }
+
+                var countryKey = NormalizeKey(countryName);
+                if (countryKey is null || !countriesByName.TryGetValue(countryKey, out var country))
+                {
+                    result.CountriesSkipped++;
+                    continue;
+                }
+
+                result.CountriesMatched++;
+
+                var cityKey = CreateScopedKey(country.Id, capitalName)!;
+                var isNewCity = !citiesByKey.TryGetValue(cityKey, out var city);
+
+                if (isNewCity)
+                {
+                    city = new City
+                    {
+                        Name = capitalName,
+                        CountryId = country.Id
+                    };
+
+                    await cityRepository.AddAsync(city);
+                    citiesByKey[cityKey] = city;
+                    result.CitiesInserted++;
+                }
+                else if (NeedsCityUpdate(city!, country.Id, capitalName))
+                {
+                    city!.Name = capitalName;
+                    city.CountryId = country.Id;
+                    result.CitiesUpdated++;
+                }
+
+                if (city is null)
+                {
+                    result.CountriesSkipped++;
+                    continue;
+                }
+
+                if (city.Id == 0)
+                {
+                    if (pendingTownKeys.Add(cityKey))
+                    {
+                        await townRepository.AddAsync(new Town
+                        {
+                            Name = capitalName,
+                            City = city
+                        });
+
+                        result.TownsInserted++;
+                    }
+
+                    continue;
+                }
+
+                var townKey = CreateScopedKey(city.Id, capitalName)!;
+                if (!townsByKey.TryGetValue(townKey, out var town))
+                {
+                    town = new Town
+                    {
+                        Name = capitalName,
+                        CityId = city.Id
+                    };
+
+                    await townRepository.AddAsync(town);
+                    townsByKey[townKey] = town;
+                    result.TownsInserted++;
+                    continue;
+                }
+
+                if (NeedsTownUpdate(town, city.Id, capitalName))
+                {
+                    town.Name = capitalName;
+                    town.CityId = city.Id;
+                    result.TownsUpdated++;
+                }
+            }
+
+            await appDbContext.SaveChangesAsync();
+            return result;
+        }
+
+        private static bool NeedsCityUpdate(City city, int countryId, string capitalName) =>
+            city.CountryId != countryId || !string.Equals(city.Name, capitalName, StringComparison.Ordinal);
+
+        private static bool NeedsTownUpdate(Town town, int cityId, string capitalName) =>
+            town.CityId != cityId || !string.Equals(town.Name, capitalName, StringComparison.Ordinal);
+
+        private static string? NormalizeText(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+        private static string? NormalizeCapital(IEnumerable<string>? capitals) =>
+            capitals?
+                .Select(NormalizeText)
+                .FirstOrDefault(capital => !string.IsNullOrWhiteSpace(capital));
+
+        private static string? NormalizeKey(string? value) =>
+            NormalizeText(value)?.ToUpperInvariant();
+
+        private static string? CreateScopedKey(int parentId, string? value)
+        {
+            var nameKey = NormalizeKey(value);
+            return nameKey is null ? null : $"{parentId}:{nameKey}";
+        }
+    }
+}

--- a/ServerLibrary/Services/Models/RestCountryCapitalApiResponse.cs
+++ b/ServerLibrary/Services/Models/RestCountryCapitalApiResponse.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace ServerLibrary.Services.Models
+{
+    public class RestCountryCapitalApiResponse
+    {
+        [JsonPropertyName("name")]
+        public RestCountryCapitalName? Name { get; set; }
+
+        [JsonPropertyName("capital")]
+        public List<string>? Capital { get; set; }
+    }
+
+    public class RestCountryCapitalName
+    {
+        [JsonPropertyName("common")]
+        public string? Common { get; set; }
+    }
+}

--- a/Tests/ServerLibrary.UnitTests/Services/CapitalSyncServiceTests.cs
+++ b/Tests/ServerLibrary.UnitTests/Services/CapitalSyncServiceTests.cs
@@ -1,0 +1,329 @@
+using System.Net;
+using System.Text;
+using BaseLibrary.Entities;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using ServerLibrary.Data;
+using ServerLibrary.Repositories.Contracts;
+using ServerLibrary.Services.Implementations;
+
+namespace ServerLibrary.UnitTests.Services;
+
+public class CapitalSyncServiceTests
+{
+    [Fact]
+    public async Task SyncCapitalsFromRestCountriesAsync_MatchedCountry_InsertsCityAndTown()
+    {
+        List<Country> countries =
+        [
+            new Country { Id = 1, Name = "Spain" }
+        ];
+        List<City> cities = [];
+        List<Town> towns = [];
+
+        var countryRepositoryMock = CreateCountryRepositoryMock(countries);
+        var cityRepositoryMock = CreateCityRepositoryMock(cities);
+        var townRepositoryMock = CreateTownRepositoryMock(towns);
+        var appDbContextMock = CreateDbContextMock();
+        var httpClientFactoryMock = CreateHttpClientFactoryMock(
+            HttpStatusCode.OK,
+            """
+            [
+              {
+                "name": { "common": " Spain " },
+                "capital": ["Madrid"]
+              }
+            ]
+            """);
+
+        var service = new CapitalSyncService(
+            countryRepositoryMock.Object,
+            cityRepositoryMock.Object,
+            townRepositoryMock.Object,
+            appDbContextMock.Object,
+            httpClientFactoryMock.Object);
+
+        var result = await service.SyncCapitalsFromRestCountriesAsync();
+
+        var city = Assert.Single(cities);
+        var town = Assert.Single(towns);
+
+        Assert.Equal(1, result.CountriesMatched);
+        Assert.Equal(0, result.CountriesSkipped);
+        Assert.Equal(1, result.CitiesInserted);
+        Assert.Equal(0, result.CitiesUpdated);
+        Assert.Equal(1, result.TownsInserted);
+        Assert.Equal(0, result.TownsUpdated);
+        Assert.Equal(1, result.RecordsProcessed);
+        Assert.Equal("Madrid", city.Name);
+        Assert.Equal(1, city.CountryId);
+        Assert.Equal("Madrid", town.Name);
+        Assert.Equal(city.Id, town.CityId);
+
+        cityRepositoryMock.Verify(repository => repository.AddAsync(It.IsAny<City>()), Times.Once);
+        townRepositoryMock.Verify(repository => repository.AddAsync(It.IsAny<Town>()), Times.Once);
+        appDbContextMock.Verify(context => context.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncCapitalsFromRestCountriesAsync_ExistingCityAndTown_UpdatesCapitalCasingWithoutDuplicating()
+    {
+        List<Country> countries =
+        [
+            new Country { Id = 1, Name = "Spain" }
+        ];
+        List<City> cities =
+        [
+            new City { Id = 10, Name = "madrid", CountryId = 1 }
+        ];
+        List<Town> towns =
+        [
+            new Town { Id = 20, Name = "madrid", CityId = 10 }
+        ];
+
+        var countryRepositoryMock = CreateCountryRepositoryMock(countries);
+        var cityRepositoryMock = CreateCityRepositoryMock(cities);
+        var townRepositoryMock = CreateTownRepositoryMock(towns);
+        var appDbContextMock = CreateDbContextMock();
+        var httpClientFactoryMock = CreateHttpClientFactoryMock(
+            HttpStatusCode.OK,
+            """
+            [
+              {
+                "name": { "common": "Spain" },
+                "capital": ["Madrid"]
+              }
+            ]
+            """);
+
+        var service = new CapitalSyncService(
+            countryRepositoryMock.Object,
+            cityRepositoryMock.Object,
+            townRepositoryMock.Object,
+            appDbContextMock.Object,
+            httpClientFactoryMock.Object);
+
+        var result = await service.SyncCapitalsFromRestCountriesAsync();
+
+        var city = Assert.Single(cities);
+        var town = Assert.Single(towns);
+
+        Assert.Equal(1, result.CountriesMatched);
+        Assert.Equal(0, result.CountriesSkipped);
+        Assert.Equal(0, result.CitiesInserted);
+        Assert.Equal(1, result.CitiesUpdated);
+        Assert.Equal(0, result.TownsInserted);
+        Assert.Equal(1, result.TownsUpdated);
+        Assert.Equal("Madrid", city.Name);
+        Assert.Equal("Madrid", town.Name);
+
+        cityRepositoryMock.Verify(repository => repository.AddAsync(It.IsAny<City>()), Times.Never);
+        townRepositoryMock.Verify(repository => repository.AddAsync(It.IsAny<Town>()), Times.Never);
+        appDbContextMock.Verify(context => context.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncCapitalsFromRestCountriesAsync_NoCountryMatch_SkipsRecord()
+    {
+        List<Country> countries =
+        [
+            new Country { Id = 1, Name = "Spain" }
+        ];
+        List<City> cities = [];
+        List<Town> towns = [];
+
+        var countryRepositoryMock = CreateCountryRepositoryMock(countries);
+        var cityRepositoryMock = CreateCityRepositoryMock(cities);
+        var townRepositoryMock = CreateTownRepositoryMock(towns);
+        var appDbContextMock = CreateDbContextMock();
+        var httpClientFactoryMock = CreateHttpClientFactoryMock(
+            HttpStatusCode.OK,
+            """
+            [
+              {
+                "name": { "common": "Portugal" },
+                "capital": ["Lisbon"]
+              }
+            ]
+            """);
+
+        var service = new CapitalSyncService(
+            countryRepositoryMock.Object,
+            cityRepositoryMock.Object,
+            townRepositoryMock.Object,
+            appDbContextMock.Object,
+            httpClientFactoryMock.Object);
+
+        var result = await service.SyncCapitalsFromRestCountriesAsync();
+
+        Assert.Equal(0, result.CountriesMatched);
+        Assert.Equal(1, result.CountriesSkipped);
+        Assert.Empty(cities);
+        Assert.Empty(towns);
+
+        cityRepositoryMock.Verify(repository => repository.AddAsync(It.IsAny<City>()), Times.Never);
+        townRepositoryMock.Verify(repository => repository.AddAsync(It.IsAny<Town>()), Times.Never);
+        appDbContextMock.Verify(context => context.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncCapitalsFromRestCountriesAsync_UsesFirstNonEmptyCapital()
+    {
+        List<Country> countries =
+        [
+            new Country { Id = 1, Name = "South Africa" }
+        ];
+        List<City> cities = [];
+        List<Town> towns = [];
+
+        var countryRepositoryMock = CreateCountryRepositoryMock(countries);
+        var cityRepositoryMock = CreateCityRepositoryMock(cities);
+        var townRepositoryMock = CreateTownRepositoryMock(towns);
+        var appDbContextMock = CreateDbContextMock();
+        var httpClientFactoryMock = CreateHttpClientFactoryMock(
+            HttpStatusCode.OK,
+            """
+            [
+              {
+                "name": { "common": "South Africa" },
+                "capital": ["", "Pretoria", "Cape Town"]
+              }
+            ]
+            """);
+
+        var service = new CapitalSyncService(
+            countryRepositoryMock.Object,
+            cityRepositoryMock.Object,
+            townRepositoryMock.Object,
+            appDbContextMock.Object,
+            httpClientFactoryMock.Object);
+
+        var result = await service.SyncCapitalsFromRestCountriesAsync();
+
+        var city = Assert.Single(cities);
+        var town = Assert.Single(towns);
+
+        Assert.Equal(1, result.CountriesMatched);
+        Assert.Equal("Pretoria", city.Name);
+        Assert.Equal("Pretoria", town.Name);
+    }
+
+    [Fact]
+    public async Task SyncCapitalsFromRestCountriesAsync_WithoutUsableCapital_SkipsRecord()
+    {
+        List<Country> countries =
+        [
+            new Country { Id = 1, Name = "Spain" }
+        ];
+        List<City> cities = [];
+        List<Town> towns = [];
+
+        var countryRepositoryMock = CreateCountryRepositoryMock(countries);
+        var cityRepositoryMock = CreateCityRepositoryMock(cities);
+        var townRepositoryMock = CreateTownRepositoryMock(towns);
+        var appDbContextMock = CreateDbContextMock();
+        var httpClientFactoryMock = CreateHttpClientFactoryMock(
+            HttpStatusCode.OK,
+            """
+            [
+              {
+                "name": { "common": "Spain" },
+                "capital": [" ", ""]
+              }
+            ]
+            """);
+
+        var service = new CapitalSyncService(
+            countryRepositoryMock.Object,
+            cityRepositoryMock.Object,
+            townRepositoryMock.Object,
+            appDbContextMock.Object,
+            httpClientFactoryMock.Object);
+
+        var result = await service.SyncCapitalsFromRestCountriesAsync();
+
+        Assert.Equal(0, result.CountriesMatched);
+        Assert.Equal(1, result.CountriesSkipped);
+        Assert.Empty(cities);
+        Assert.Empty(towns);
+    }
+
+    private static Mock<AppDbContext> CreateDbContextMock()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>().Options;
+        var appDbContextMock = new Mock<AppDbContext>(options);
+        appDbContextMock.Setup(context => context.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+        return appDbContextMock;
+    }
+
+    private static Mock<ICountryRepository> CreateCountryRepositoryMock(List<Country> countries)
+    {
+        var repositoryMock = new Mock<ICountryRepository>();
+        repositoryMock.Setup(repository => repository.GetAll()).ReturnsAsync(countries);
+        return repositoryMock;
+    }
+
+    private static Mock<ICityRepository> CreateCityRepositoryMock(List<City> cities)
+    {
+        var repositoryMock = new Mock<ICityRepository>();
+
+        repositoryMock.Setup(repository => repository.GetAllForSyncAsync()).ReturnsAsync(cities);
+        repositoryMock.Setup(repository => repository.AddAsync(It.IsAny<City>()))
+            .Callback<City>(city =>
+            {
+                city.Id = cities.Count == 0 ? 1 : cities.Max(existingCity => existingCity.Id) + 1;
+                cities.Add(city);
+            })
+            .Returns(Task.CompletedTask);
+
+        return repositoryMock;
+    }
+
+    private static Mock<ITownRepository> CreateTownRepositoryMock(List<Town> towns)
+    {
+        var repositoryMock = new Mock<ITownRepository>();
+
+        repositoryMock.Setup(repository => repository.GetAllForSyncAsync()).ReturnsAsync(towns);
+        repositoryMock.Setup(repository => repository.AddAsync(It.IsAny<Town>()))
+            .Callback<Town>(town =>
+            {
+                if (town.City is not null && town.CityId == 0)
+                {
+                    town.CityId = town.City.Id;
+                }
+
+                town.Id = towns.Count == 0 ? 1 : towns.Max(existingTown => existingTown.Id) + 1;
+                towns.Add(town);
+            })
+            .Returns(Task.CompletedTask);
+
+        return repositoryMock;
+    }
+
+    private static Mock<IHttpClientFactory> CreateHttpClientFactoryMock(HttpStatusCode statusCode, string content)
+    {
+        var handler = new FakeHttpMessageHandler(_ => new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(content, Encoding.UTF8, "application/json")
+        });
+
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://restcountries.com/")
+        };
+
+        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        httpClientFactoryMock
+            .Setup(factory => factory.CreateClient("RestCountries"))
+            .Returns(httpClient);
+
+        return httpClientFactoryMock;
+    }
+
+    private sealed class FakeHttpMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(handler(request));
+    }
+}


### PR DESCRIPTION
…/City/Town hierarchy. The new flow calls REST Countries from the server, matches existing Country rows by trimmed case-insensitive name, upserts City as the capital under that country, upserts Town with the same capital name under that city, and exposes the action in the existing Country page as an admin-only Sync Capitals button.