### PR TITLE
Fix: Cache Invalidation for Department, General Department, and Branch CRUD

### DIFF
--- a/Client/Pages/ContentPages/DepartmentPages/GeneralDepartmentPage.razor
+++ b/Client/Pages/ContentPages/DepartmentPages/GeneralDepartmentPage.razor
@@ -88,7 +88,7 @@
     public List<GeneralDepartment> GeneralDepartments = new();
     public string Title { get; set; } = "Add";
 
-    protected async override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         await GetGeneralDepartments();
         allState.Action += StateHasChanged;

--- a/Server/Controllers/BranchController.cs
+++ b/Server/Controllers/BranchController.cs
@@ -34,8 +34,31 @@ namespace Server.Controllers
                 .SetPriority(CacheItemPriority.Normal);
 
             cache.Set(BranchCacheKey, branches, cacheEntryOptions);
-
             return Ok(branches);
+        }
+
+        [HttpPost("add")]
+        public override async Task<IActionResult> Add(Branch model)
+        {
+            var result = await base.Add(model);
+            cache.Remove(BranchCacheKey);
+            return result;
+        }
+
+        [HttpPut("update")]
+        public override async Task<IActionResult> Update(Branch model)
+        {
+            var result = await base.Update(model);
+            cache.Remove(BranchCacheKey);
+            return result;
+        }
+
+        [HttpDelete("delete/{id}")]
+        public override async Task<IActionResult> Delete(int id)
+        {
+            var result = await base.Delete(id);
+            cache.Remove(BranchCacheKey);
+            return result;
         }
     }
 }

--- a/Server/Controllers/DepartmentController.cs
+++ b/Server/Controllers/DepartmentController.cs
@@ -35,10 +35,31 @@ namespace Server.Controllers
                 .SetPriority(CacheItemPriority.Normal);
 
             cache.Set(DepartmentCacheKey, departments, cacheEntryOptions);
-
             return Ok(departments);
         }
 
-}
+        [HttpPost("add")]
+        public override async Task<IActionResult> Add(Department model)
+        {
+            var result = await base.Add(model);
+            cache.Remove(DepartmentCacheKey);
+            return result;
+        }
 
+        [HttpPut("update")]
+        public override async Task<IActionResult> Update(Department model)
+        {
+            var result = await base.Update(model);
+            cache.Remove(DepartmentCacheKey);
+            return result;
+        }
+
+        [HttpDelete("delete/{id}")]
+        public override async Task<IActionResult> Delete(int id)
+        {
+            var result = await base.Delete(id);
+            cache.Remove(DepartmentCacheKey);
+            return result;
+        }
+    }
 }

--- a/Server/Controllers/GeneralDepartmentController.cs
+++ b/Server/Controllers/GeneralDepartmentController.cs
@@ -36,8 +36,31 @@ namespace Server.Controllers
                 .SetPriority(CacheItemPriority.Normal);
 
             cache.Set(GeneralDepartmentCacheKey, generalDepartments, cacheEntryOptions);
-
             return Ok(generalDepartments);
+        }
+
+        [HttpPost("add")]
+        public override async Task<IActionResult> Add(GeneralDepartment model)
+        {
+            var result = await base.Add(model);
+            cache.Remove(GeneralDepartmentCacheKey);
+            return result;
+        }
+
+        [HttpPut("update")]
+        public override async Task<IActionResult> Update(GeneralDepartment model)
+        {
+            var result = await base.Update(model);
+            cache.Remove(GeneralDepartmentCacheKey);
+            return result;
+        }
+
+        [HttpDelete("delete/{id}")]
+        public override async Task<IActionResult> Delete(int id)
+        {
+            var result = await base.Delete(id);
+            cache.Remove(GeneralDepartmentCacheKey);
+            return result;
         }
     }
 }

--- a/Server/Controllers/GenericController.cs
+++ b/Server/Controllers/GenericController.cs
@@ -18,10 +18,10 @@ namespace Server.Controllers
         public virtual async Task<IActionResult> GetAll() => Ok(await genericRepositoryInterface.GetAll());
 
         [HttpDelete("delete/{id}")]
-        public async Task<IActionResult> Delete(int id)
+        public virtual async Task<IActionResult> Delete(int id)
         {
             if (id <= 0) return BadRequest("Invalid request sent");
-            return Ok(await genericRepositoryInterface.DeleteById(id)); 
+            return Ok(await genericRepositoryInterface.DeleteById(id));
         }
 
         [HttpGet("single/{id}")]
@@ -32,14 +32,14 @@ namespace Server.Controllers
         }
 
         [HttpPost("add")]
-        public async Task<IActionResult> Add(T model)
+        public virtual async Task<IActionResult> Add(T model)
         {
             if (model is null) return BadRequest("Bad request made");
             return Ok(await genericRepositoryInterface.Insert(model));
         }
 
         [HttpPut("update")]
-        public async Task<IActionResult> Update(T model)
+        public virtual async Task<IActionResult> Update(T model)
         {
             if (model is null) return BadRequest("Bad request made");
             return Ok(await genericRepositoryInterface.Update(model));


### PR DESCRIPTION
##  Root Cause

All three controllers — **DepartmentController**, **GeneralDepartmentController**, and **BranchController** — cached the result of `GET /all` using `IMemoryCache`.

However, **none of the write operations** (Add, Update, Delete) invalidated the cache.

This caused a silent but severe consistency bug:

- User deletes an item → DB row is removed correctly  
- UI refreshes → calls `GET /api/.../all`  
- Controller returns **stale cached list**  
- Deleted item reappears → looks like delete “didn’t work”

The same issue affected:

- **Add** → new item never appears  
- **Update** → name changes don’t show  
- **Branch** and **General Department** lists → identical stale-cache behavior  

This was a classic **cache invalidation bug**.

---

## What Was Changed

| File | Change |
|------|--------|
| **GenericController.cs** | Added `virtual` to `Add`, `Update`, `Delete` so derived controllers can override them cleanly |
| **DepartmentController.cs** | Overrides `Add`, `Update`, `Delete` → calls `base.*` then `cache.Remove(DepartmentCacheKey)` |
| **GeneralDepartmentController.cs** | Same override pattern → removes `GeneralDepartmentCacheKey` |
| **BranchController.cs** | Same override pattern → removes `BranchCacheKey` |
| **GeneralDepartmentPage.razor** | Replaced `async void OnInitialized` with `async Task OnInitializedAsync` for proper async lifecycle behavior |

### Additional Notes
- Cache keys are now invalidated **immediately** after any write operation.  
- GET endpoints now always return fresh data after Add/Update/Delete.  
- UI list refreshes correctly without requiring a manual page reload.

---

## Verification Steps

### **1. Delete Flow**
1. Start the server  
2. Navigate to General Department / Department / Branch page  
3. Delete an item with no children  
4. Confirm the delete  
5. **Expected:**  
   - Item disappears immediately  
   - No reappearing on refresh  
   - API returns fresh data (no stale cache)

---

### **2. Add Flow**
1. Add a new department  
2. **Expected:**  
   - New item appears instantly  
   - No manual refresh needed  

---

### **3. Update Flow**
1. Rename a department  
2. **Expected:**  
   - Updated name appears immediately  
   - No stale cached version returned  

---

### **4. API Verification**
Using Swagger/Postman:

- Call `GET /api/department/all` before and after operations  
- Confirm the returned list always reflects the latest DB state  

---

### **5. Regression Check**
- Ensure no other controllers rely on the old caching pattern  
- Confirm no unintended cache removals occur  

---

## Outcome

This PR resolves a long-standing consistency issue where hierarchical lists appeared to “not update” after CRUD operations.

The fix ensures:

- Correct cache invalidation  
- Accurate UI updates  
- Predictable behavior across all three entity types  
- Clean override pattern aligned with proper controller inheritance  

The system now behaves reliably and consistently for all Add/Update/Delete flows.