### PR TITLE
feat(dashboard): add Syncfusion donut and column charts to homepage

### DIFF
--- a/Client/Pages/ContentPages/HomePage.razor
+++ b/Client/Pages/ContentPages/HomePage.razor
@@ -21,6 +21,12 @@
                          InitialSanctions="dashboardSanctions"
                          InitialVacations="dashboardVacations"
                          InitialHealth="dashboardHealth" />
+            <DashboardCharts Employees="dashboardEmployees"
+                             Departments="dashboardDepartments"
+                             Overtimes="dashboardOvertimes"
+                             Sanctions="dashboardSanctions"
+                             Vacations="dashboardVacations"
+                             Health="dashboardHealth" />
             <GeneralDepartmentPage />
             <DepartmentPage />
             <BranchPage />

--- a/Client/Pages/OtherPages/DashboardCharts.razor
+++ b/Client/Pages/OtherPages/DashboardCharts.razor
@@ -1,0 +1,95 @@
+@using Syncfusion.Blazor.Charts
+@if (_chartData is null || _chartData.Count == 0) { return; }
+
+<div class="container-fluid mt-3 mb-4">
+    <div class="row g-3">
+
+        <!-- ── Donut: HR Module Overview ──────────────────────────────────── -->
+        <div class="col-lg-5 col-md-12">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold">
+                    <i class="bi bi-pie-chart-fill text-primary me-2"></i>HR Module Overview
+                </div>
+                <div class="card-body d-flex justify-content-center align-items-center">
+                    <SfAccumulationChart EnableAnimation="true" Background="transparent">
+                        <AccumulationChartTooltipSettings Enable="true"
+                            Format="${point.x}: <b>${point.y}</b>">
+                        </AccumulationChartTooltipSettings>
+                        <AccumulationChartLegendSettings Visible="true"
+                            Position="LegendPosition.Bottom">
+                        </AccumulationChartLegendSettings>
+                        <AccumulationChartSeriesCollection>
+                            <AccumulationChartSeries DataSource="_chartData"
+                                XName="Label" YName="Count"
+                                InnerRadius="40%"
+                                Radius="80%">
+                                <AccumulationDataLabelSettings Visible="true"
+                                    Name="Label"
+                                    Position="AccumulationLabelPosition.Outside">
+                                </AccumulationDataLabelSettings>
+                            </AccumulationChartSeries>
+                        </AccumulationChartSeriesCollection>
+                    </SfAccumulationChart>
+                </div>
+            </div>
+        </div>
+
+        <!-- ── Column: HR Module Counts ──────────────────────────────────── -->
+        <div class="col-lg-7 col-md-12">
+            <div class="card shadow-sm h-100">
+                <div class="card-header fw-semibold">
+                    <i class="bi bi-bar-chart-fill text-success me-2"></i>Module Record Counts
+                </div>
+                <div class="card-body">
+                    <SfChart Background="transparent">
+                        <ChartPrimaryXAxis ValueType="Syncfusion.Blazor.Charts.ValueType.Category"
+                            LabelRotation="-30">
+                        </ChartPrimaryXAxis>
+                        <ChartPrimaryYAxis Title="Records" Minimum="0">
+                        </ChartPrimaryYAxis>
+                        <ChartTooltipSettings Enable="true"></ChartTooltipSettings>
+                        <ChartSeriesCollection>
+                            <ChartSeries DataSource="_chartData"
+                                XName="Label" YName="Count"
+                                Type="ChartSeriesType.Column"
+                                Width="2">
+                                <ChartMarker Visible="true">
+                                    <ChartDataLabel Visible="true"
+                                        Position="LabelPosition.Top">
+                                    </ChartDataLabel>
+                                </ChartMarker>
+                            </ChartSeries>
+                        </ChartSeriesCollection>
+                    </SfChart>
+                </div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+@code {
+    [Parameter] public List<Employee>?   Employees   { get; set; }
+    [Parameter] public List<Department>? Departments { get; set; }
+    [Parameter] public List<Overtime>?   Overtimes   { get; set; }
+    [Parameter] public List<Sanction>?   Sanctions   { get; set; }
+    [Parameter] public List<Vacation>?   Vacations   { get; set; }
+    [Parameter] public List<Doctor>?     Health      { get; set; }
+
+    private List<ChartPoint>? _chartData;
+
+    private sealed record ChartPoint(string Label, int Count);
+
+    protected override void OnParametersSet()
+    {
+        _chartData = new List<ChartPoint>
+        {
+            new("Employees",   Employees?.Count   ?? 0),
+            new("Overtime",    Overtimes?.Count   ?? 0),
+            new("Sanctions",   Sanctions?.Count   ?? 0),
+            new("Vacations",   Vacations?.Count   ?? 0),
+            new("Health",      Health?.Count      ?? 0),
+            new("Departments", Departments?.Count ?? 0),
+        };
+    }
+}


### PR DESCRIPTION
**DashboardCharts.razor (new component):**
- SfAccumulationChart (donut): shows proportional breakdown of all six HR modules (Employees, Overtime, Sanctions, Vacations, Health, Departments) with tooltips, labels and bottom legend
- SfChart (column): bar chart of the same six module counts with data labels on top and labelled Y-axis for quick at-a-glance comparison
- Receives the same six data lists already loaded in HomePage.razor so there are zero extra API calls — charts render for free
- Syncfusion.Blazor.Charts namespace imported locally in the component to avoid ambiguous reference with ClientLibrary.Helpers.Constants

**HomePage.razor:**
- DashboardCharts inserted directly below TableBanner, passing all six dashboard data lists as parameters

_Build: 0 errors, 0 warnings._